### PR TITLE
Improve missing contacts and missing exposures

### DIFF
--- a/android/app/src/main/java/edu/illinois/covid/Constants.java
+++ b/android/app/src/main/java/edu/illinois/covid/Constants.java
@@ -84,7 +84,7 @@ public class Constants {
     public static final String EXPOSURE_BLE_ACTION_FOUND = "edu.illinois.rokwire.exposure.ble.scan.ACTION_FOUND";
     public static final int EXPOSURE_NO_RSSI_VALUE = 127;
     public static final int EXPOSURE_MIN_RSSI_VALUE = -50;
-    public static final int EXPOSURE_MIN_DURATION_MILLIS = 2 * 60 * 1000; // 2 minutes
+    public static final int EXPOSURE_MIN_DURATION_MILLIS = 0; // 0 minute
     public static final UUID EXPOSURE_UUID_SERVICE = UUID.fromString("0000CD19-0000-1000-8000-00805F9B34FB");
     public static final ParcelUuid EXPOSURE_PARCEL_SERVICE_UUID = new ParcelUuid(EXPOSURE_UUID_SERVICE);
     public static final UUID EXPOSURE_UUID_CHARACTERISTIC = UUID.fromString("1f5bb1de-cdf0-4424-9d43-d8cc81a7f207");

--- a/android/app/src/main/java/edu/illinois/covid/exposure/ExposurePlugin.java
+++ b/android/app/src/main/java/edu/illinois/covid/exposure/ExposurePlugin.java
@@ -769,6 +769,11 @@ public class ExposurePlugin implements MethodChannel.MethodCallHandler {
 
         int startENIntervalNumber = (int) (timestampInSecs / RPI_REFRESH_INTERVAL_SECS);
         int endENIntervalNumber = (int) (expireTimeInSecs / RPI_REFRESH_INTERVAL_SECS);
+
+        /* handle TEKs without expirestamp (0 or -1), default to 1 day later */
+        if (endENIntervalNumber < startENIntervalNumber || endENIntervalNumber > startENIntervalNumber + TEKRollingPeriod)
+            endENIntervalNumber = startENIntervalNumber + TEKRollingPeriod;
+
         Map<String, Long> rpiList = new HashMap<>();
         for (int intervalIndex = startENIntervalNumber; intervalIndex <= endENIntervalNumber; intervalIndex++) {
             byte[] rpi = generateRpiForIntervalNumber(intervalIndex, tek);

--- a/ios/Runner/ExposurePlugin.m
+++ b/ios/Runner/ExposurePlugin.m
@@ -75,7 +75,7 @@ static NSTimeInterval const kExposurePingInterval            =  60;     // 1 min
 static NSTimeInterval const kExposureProcessInterval         =  10;     // 10 sec
 static NSTimeInterval const kLocalNotificationInterval       =  60;     // 1 minute
 static NSTimeInterval const kExposureNotifyTickInterval      =   1;     // 1 sec
-static NSTimeInterval const kExposureMinDuration             = 120;     // 2 minutes
+static NSTimeInterval const kExposureMinDuration             =	 0;     // 0 minute
 
 static int const kNoRssi = 127;
 static int const kMinRssi = -50;
@@ -1032,6 +1032,10 @@ static ExposurePlugin *g_Instance = nil;
 	/* obtain start/endENInvertalNumber and timestamp i for teks generation */
 	uint32_t startENInvertalNumber = timestampInterval / kRPIRefreshInterval;
 	uint32_t endENInvertalNumber = expirestampInterval / kRPIRefreshInterval;
+
+	/* handle TEKs without expirestamp (0 or -1), default to 1 day later */
+	if (endENInvertalNumber < startENInvertalNumber || endENInvertalNumber > startENInvertalNumber + kTEKRollingPeriod)
+		endENInvertalNumber = startENInvertalNumber + kTEKRollingPeriod;
 	
 	NSMutableDictionary *rpis = [[NSMutableDictionary alloc] init];
 	for (uint32_t intervalIndex = startENInvertalNumber; intervalIndex <= endENInvertalNumber; intervalIndex++) {


### PR DESCRIPTION
1. Reduce missing contacts by setting Exposure Min Duration to 0. Server config needs to be changed correspondingly. (proved to be effective during on site test, as the durations of exposure are not reliable.)
2. Handle TEKs without expirestamp (expirestamp entry is 0/-1). If a TEK's expirestamp is null or invalid, set it to its start timestamp + 1 day (144) 
