### PR TITLE
Dont add/process OSF test if it's not enetered as test type within th…

### DIFF
--- a/lib/service/Health.dart
+++ b/lib/service/Health.dart
@@ -1063,13 +1063,16 @@ class Health with Service implements NotificationsListener {
   }
 
   Future<int> processOsfTests({List<Covid19OSFTest> osfTests}) async {
+
+    List<HealthTestType> testTypes = await loadHealthServiceTestTypes();
+    Set<String> testTypeSet = testTypes != null ? testTypes.map((entry) => entry.name).toSet() : null;
     if (osfTests != null) {
       List<Covid19OSFTest> processed = List<Covid19OSFTest>();
       DateTime lastOsfTestDate = Storage().lastHealthCovid19OsfTestDate;
       DateTime latestOsfTestDate;
 
       for (Covid19OSFTest osfTest in osfTests) {
-        if ((osfTest.dateUtc != null) && (lastOsfTestDate == null || lastOsfTestDate.isBefore(osfTest.dateUtc))) {
+        if ((testTypeSet != null && testTypeSet.contains(osfTest.testType)) && osfTest.dateUtc != null && (lastOsfTestDate == null || lastOsfTestDate.isBefore(osfTest.dateUtc))) {
           Covid19History testHistory = await _applyOsfTestHistory(osfTest);
           if (testHistory != null) {
             processed.add(osfTest);


### PR DESCRIPTION
My understanding is that, the rules have another purpose mainly related to the status. Good approach is to check for test types and use that endpoint and process only test with the exact test type name