### PR TITLE
Log building access on each status update (#208).

### DIFF
--- a/lib/service/Storage.dart
+++ b/lib/service/Storage.dart
@@ -441,16 +441,6 @@ class Storage with Service {
     _setStringWithName(lastHealthCovid19StatusKey, value);
   }
 
-  static const String lastHealthCovid19AccessKey = 'health_last_covid19_access';
-
-  String get lastHealthCovid19Access {
-    return _getStringWithName(lastHealthCovid19AccessKey);
-  }
-
-  set lastHealthCovid19Access(String value) {
-    _setStringWithName(lastHealthCovid19AccessKey, value);
-  }
-
   static const String healthUserKey = 'health_user';
 
   String get healthUser {

--- a/lib/ui/health/Covid19StatusPanel.dart
+++ b/lib/ui/health/Covid19StatusPanel.dart
@@ -127,7 +127,7 @@ class _Covid19StatusPanelState extends State<Covid19StatusPanel> implements Noti
   }
 
   void _updateCovid19Access() {
-    Health().isAccessGranted(_covid19Status?.blob?.healthStatus).then((bool granted) {
+    Health().isBuildingAccessGranted(_covid19Status?.blob?.healthStatus).then((bool granted) {
       if (mounted) {
         setState(() {
           _covid19Access = granted;


### PR DESCRIPTION
Use everywhere "building access" instead of just "access".