### PR TITLE
Change to second most recent test

### DIFF
--- a/lib/model/Health.dart
+++ b/lib/model/Health.dart
@@ -478,6 +478,34 @@ class Covid19History {
     return null;
   }
 
+  static Covid19History secondMostRecentTest(List<Covid19History> histories, {DateTime beforeDateUtc}) {
+    // returns the second most recent test
+    if (histories != null) {
+      if (beforeDateUtc == null) {
+        beforeDateUtc = DateTime.now().toUtc();
+      }
+      int count = 0;
+      Covid19History mostRecentTest;
+      for (int index = 0; index < histories.length; index++) {
+        Covid19History history = histories[index];
+        if (history.isTestVerified && (history.dateUtc != null) && (history.dateUtc.isBefore(beforeDateUtc))) {
+          count += 1;
+          if (count == 1) {
+            mostRecentTest = history;
+          } else if (count == 2) {
+            return history;
+          }
+        }
+      }
+
+      // return most recent test if second most recent doesn't exist
+      if (mostRecentTest != null) {
+        return mostRecentTest;
+      }
+    }
+    return null;
+  }
+
   static List<Covid19History> pastList(List<Covid19History> histories) {
     List<Covid19History> result;
     if (histories != null) {

--- a/lib/model/Health.dart
+++ b/lib/model/Health.dart
@@ -463,47 +463,21 @@ class Covid19History {
     return null;
   }
 
-  static Covid19History mostRecentTest(List<Covid19History> histories, {DateTime beforeDateUtc}) {
+  static Covid19History mostRecentTest(List<Covid19History> histories, { DateTime beforeDateUtc, int onPosition = 1 }) {
+    Covid19History result;
     if (histories != null) {
       if (beforeDateUtc == null) {
         beforeDateUtc = DateTime.now().toUtc();
       }
-      for (int index = 0; index < histories.length; index++) {
+      for (int index = 0; (index < histories.length) && (0 < onPosition); index++) {
         Covid19History history = histories[index];
         if (history.isTestVerified && (history.dateUtc != null) && (history.dateUtc.isBefore(beforeDateUtc))) {
-          return history;
+          result = history;
+          onPosition--;
         }
       }
     }
-    return null;
-  }
-
-  static Covid19History secondMostRecentTest(List<Covid19History> histories, {DateTime beforeDateUtc}) {
-    // returns the second most recent test
-    if (histories != null) {
-      if (beforeDateUtc == null) {
-        beforeDateUtc = DateTime.now().toUtc();
-      }
-      int count = 0;
-      Covid19History mostRecentTest;
-      for (int index = 0; index < histories.length; index++) {
-        Covid19History history = histories[index];
-        if (history.isTestVerified && (history.dateUtc != null) && (history.dateUtc.isBefore(beforeDateUtc))) {
-          count += 1;
-          if (count == 1) {
-            mostRecentTest = history;
-          } else if (count == 2) {
-            return history;
-          }
-        }
-      }
-
-      // return most recent test if second most recent doesn't exist
-      if (mostRecentTest != null) {
-        return mostRecentTest;
-      }
-    }
-    return null;
+    return result;
   }
 
   static List<Covid19History> pastList(List<Covid19History> histories) {

--- a/lib/service/Health.dart
+++ b/lib/service/Health.dart
@@ -893,7 +893,7 @@ class Health with Service implements NotificationsListener {
       int exposureTestReportDays = Config().settings['covid19ExposureTestReportDays'];
       for (Covid19Event event in events) {
         if (event.isTest) {
-          Covid19History previousTest = Covid19History.secondMostRecentTest(histories, beforeDateUtc: event.blob?.dateUtc);
+          Covid19History previousTest = Covid19History.mostRecentTest(histories, beforeDateUtc: event.blob?.dateUtc, onPosition: 2);
           Exposure().evalTestResultExposureScoring(previousTestDateUtc: previousTest?.dateUtc).then((int score) {
             Analytics().logHealth(
               action: Analytics.LogHealthProviderTestProcessedAction,

--- a/lib/service/Health.dart
+++ b/lib/service/Health.dart
@@ -893,7 +893,7 @@ class Health with Service implements NotificationsListener {
       int exposureTestReportDays = Config().settings['covid19ExposureTestReportDays'];
       for (Covid19Event event in events) {
         if (event.isTest) {
-          Covid19History previousTest = Covid19History.mostRecentTest(histories, beforeDateUtc: event.blob?.dateUtc);
+          Covid19History previousTest = Covid19History.secondMostRecentTest(histories, beforeDateUtc: event.blob?.dateUtc);
           Exposure().evalTestResultExposureScoring(previousTestDateUtc: previousTest?.dateUtc).then((int score) {
             Analytics().logHealth(
               action: Analytics.LogHealthProviderTestProcessedAction,


### PR DESCRIPTION
Because the virus takes a few days to take hold, we might not see the corresponding positive case until the subsequent test. Therefore, we change the time frame to look back from the second most recent test. The only function added is `static Covid19History secondMostRecentTest` in `model/Health.dart`.