### PR TITLE
Add ExposureUpTime to log Exposure Notification Running Time in past X hours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Do not edit straightly roles from user data [#229](https://github.com/rokwire/illinois-app/issues/229).
 - Increased connectivity plugin version [#519](https://github.com/rokwire/safer-illinois-app/issues/519).
 
+### Added
+- App Up time to exposure logs.
+
 ## [2.10.11] - 2021-01-19
 ### Changed
 - Changed interval between first and second test for Spring 2021 [#482](https://github.com/rokwire/safer-illinois-app/issues/482)

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -38,6 +38,7 @@
     <uses-sdk tools:overrideLibrary="com.google.zxing.client.android" />
     <!-- save_in_gallery flutter plugin -->
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <!-- BlinkID -->
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-feature android:name="android.hardware.camera" android:required="false" />

--- a/android/app/src/main/java/edu/illinois/covid/Constants.java
+++ b/android/app/src/main/java/edu/illinois/covid/Constants.java
@@ -69,11 +69,13 @@ public class Constants {
     public static final String EXPOSURE_PLUGIN_METHOD_NAME_THICK = "exposureThick";
     public static final String EXPOSURE_PLUGIN_METHOD_NAME_RSSI_LOG = "exposureRSSILog";
     public static final String EXPOSURE_PLUGIN_METHOD_NAME_EXPIRE_TEK = "expireTEK";
+    public static final String EXPOSURE_PLUGIN_METHOD_EXP_UP_TIME = "exposureUpTime";
     public static final String EXPOSURE_PLUGIN_SETTINGS_PARAM_NAME = "settings";
     public static final String EXPOSURE_PLUGIN_RPI_PARAM_NAME = "rpi";
     public static final String EXPOSURE_PLUGIN_TEK_METHOD_NAME = "tek";
     public static final String EXPOSURE_PLUGIN_TEK_PARAM_NAME = "tek";
     public static final String EXPOSURE_PLUGIN_TIMESTAMP_PARAM_NAME = "timestamp";
+    public static final String EXPOSURE_PLUGIN_UP_TIME_WIN_PARAM_NAME = "upTimeWindow";
     public static final String EXPOSURE_PLUGIN_EXPOSURE_METHOD_NAME = "exposure";
     public static final String EXPOSURE_PLUGIN_DURATION_PARAM_NAME = "duration";
     public static final String EXPOSURE_PLUGIN_RSSI_PARAM_NAME = "rssi";

--- a/android/app/src/main/java/edu/illinois/covid/exposure/ExposurePlugin.java
+++ b/android/app/src/main/java/edu/illinois/covid/exposure/ExposurePlugin.java
@@ -1263,8 +1263,8 @@ public class ExposurePlugin implements MethodChannel.MethodCallHandler, FlutterP
         }
     }
 
-    private Map<Integer, Integer> durationsInWindow (long upTimeWindow) {
-        Map<Integer, Integer> upTimeWindowResult = new HashMap<>();
+    private Integer expUpDurationInWindow (long upTimeWindow) {
+        int durationInWindow = 0;
         long currentTime = (long) Utils.DateTime.getCurrentTimeMillisSince1970() / 1000;
         long _timeWindowInSeconds = upTimeWindow * 60 * 60;
         long _expireTimestamp = currentTime - 168 * 60 * 60;
@@ -1273,16 +1273,16 @@ public class ExposurePlugin implements MethodChannel.MethodCallHandler, FlutterP
             for (Integer _time : expUpTimeMap.keySet()) {
                 if (_time.intValue() + expUpTimeMap.get(_time).intValue() >= _startTimestamp) {
                     if (_time.intValue() >= _startTimestamp) {
-                        upTimeWindowResult.put(_time, expUpTimeMap.get(_time));
+                        durationInWindow += expUpTimeMap.get(_time);
                     } else {
-                        upTimeWindowResult.put(new Integer((int) _startTimestamp), new Integer(expUpTimeMap.get(_time).intValue() + _time.intValue() - (int) _startTimestamp));
+                        durationInWindow += expUpTimeMap.get(_time).intValue() + _time.intValue() - (int) _startTimestamp;
                     }
-                } else {
+                } else if ((_time.intValue() + expUpTimeMap.get(_time).intValue()) < (int)_expireTimestamp) {
                     expUpTimeMap.remove(_time);
                 }
             }
         }
-        return upTimeWindowResult;
+        return new Integer(durationInWindow);
     }
 
     //region RPI timer
@@ -1364,7 +1364,7 @@ public class ExposurePlugin implements MethodChannel.MethodCallHandler, FlutterP
                     break;
                 case Constants.EXPOSURE_PLUGIN_METHOD_EXP_UP_TIME:
                     long upTimeWindow = Utils.Map.getValueFromPath(call.arguments, Constants.EXPOSURE_PLUGIN_UP_TIME_WIN_PARAM_NAME, 0);
-                    Map<Integer, Integer> upTimeWindowResult = durationsInWindow(upTimeWindow);
+                    Integer upTimeWindowResult = expUpDurationInWindow(upTimeWindow);
                     result.success(upTimeWindowResult);
                     break;
                 case Constants.EXPOSURE_PLUGIN_METHOD_NAME_EXPIRE_TEK:

--- a/lib/service/Analytics.dart
+++ b/lib/service/Analytics.dart
@@ -221,6 +221,9 @@ class Analytics with Service implements NotificationsListener {
   static const String   LogRpiMatches6HoursName              = "rpi_matches_6_hour";
   static const String   LogRpiMatches24HoursName             = "rpi_matches_24_hour";
   static const String   LogRpiMatches168HoursName            = "rpi_matches_168_hour";
+  static const String   LogExposureUpTime6HoursName          = "exposure_uptime_6_hour";
+  static const String   LogExposureUpTime24HoursName         = "exposure_uptime_24_hour";
+  static const String   LogExposureUpTime168HoursName        = "exposure_uptime_168_hour";
   static const String   LogTestFrequency168HoursName         = "test_frequency_168_hour";
   static const String   LogExposureNotification168HoursName  = "exposure_notification_168_hour";
   static const String   LogTestResult168HoursName            = "test_result_168_hour";

--- a/lib/service/Exposure.dart
+++ b/lib/service/Exposure.dart
@@ -313,15 +313,16 @@ class Exposure with Service implements NotificationsListener {
     _pluginSettings = null;
   }
 
-  Future<Map<int, int>> _expUpTime(int hours) async {
-    Map<dynamic, dynamic> result = await _methodChannel.invokeMethod(_expUpTimeMethodName, {
-      _upTimeWinParamName : hours,
-    });
-    return result?.cast<int, int>();
-  }
-
   Future<void> _expireTEK() async {
     await _methodChannel.invokeMethod(_expireTEKMethodName);
+  }
+
+  Future<int> evalExposureUpTime(int hours) async {
+    dynamic duration = await _methodChannel.invokeMethod(_expUpTimeMethodName, {
+      _upTimeWinParamName : hours,
+    });
+
+    return duration is int ? duration : null;
   }
 
   Future<List<ExposureTEK>> loadTeks({int minStamp, int maxStamp}) async {

--- a/lib/service/Exposure.dart
+++ b/lib/service/Exposure.dart
@@ -57,11 +57,13 @@ class Exposure with Service implements NotificationsListener {
   static const String _expireTEKMethodName             = 'expireTEK';
   static const String _exposureRPIMethodName           = 'exposureRPILog';
   static const String _exposureRSSIMethodName          = 'exposureRSSILog';
+  static const String _expUpTimeMethodName             = 'exposureUpTime';
 
   static const String _settingsParamName               = 'settings';
   static const String _tekParamName                    = 'tek';
   static const String _timestampParamName              = 'timestamp';
   static const String _expirestampParamName            = 'expirestamp';
+  static const String _upTimeWinParamName              = 'upTimeWindow';
 
   static const String _tecNotificationName              = 'tek';
   static const String _exposureNotificationName         = 'exposure';
@@ -309,6 +311,13 @@ class Exposure with Service implements NotificationsListener {
     await _methodChannel.invokeMethod(_stopMethodName);
     _isPluginStarted = false;
     _pluginSettings = null;
+  }
+
+  Future<Map<int, int>> _expUpTime(int hours) async {
+    Map<dynamic, dynamic> result = await _methodChannel.invokeMethod(_expUpTimeMethodName, {
+      _upTimeWinParamName : hours,
+    });
+    return result?.cast<int, int>();
   }
 
   Future<void> _expireTEK() async {


### PR DESCRIPTION
	modified:   android/app/src/main/AndroidManifest.xml
	modified:   android/app/src/main/java/edu/illinois/covid/Constants.java
	modified:   android/app/src/main/java/edu/illinois/covid/exposure/ExposurePlugin.java
	modified:   ios/Runner/ExposurePlugin.m
	modified:   lib/service/Exposure.dart

## Description
This pull request adds a flutter function in lib/service/Exposure.dart (Future<Map<int, int>> _expUpTime(int hours) asyn) and its platform specific code for iOS and Android.
The function takes an integer as the variable to specify how many hours of log would be retrieved, and the return value is a dictionary with key: timestamp (in UTC seconds) and value: duration (in seconds).
The implementation of iOS specific code utilizes App's life cycle and periodic notification as heartbeat (record data). The code would also check if the notification is enabled, otherwise the exposure function would not be performed as intended. The implementation of Android specific code uses a periodic timer, and the timer would update the duration value.

**Fixes #(add issue number here and remove parentheses)**

[comment]: # (This project only accepts pull requests related to open issues.)
[comment]: # (If suggesting a new feature or change, please discuss it in an issue first.)
[comment]: # (If fixing a bug, there should be an issue describing it with steps to reproduce.)

## Review Time Estimate
_Please give your idea of how soon this pull request needs to be reviewed by selecting one of the options below. This can be based on the criticality of the issue at hand and/or other relevant factors._

[comment]: # (To select an option, please put an 'x' in the applicable box.)
[comment]: # (If you're unsure about any of these, don't hesitate to ask. We're here to help!.)

- [ ] Immediately
- [ ] Within a week
- [ ] When possible

## Type of changes
_Please select a relevant option:_

[comment]: # (To select an option, please put an 'x' in the applicable box.)
[comment]: # (If you're unsure about any of these, don't hesitate to ask. We're here to help!.)

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Other (any another change that does not fall in one of the above categories.)

## Checklist:
_Please select all applicable options:_

[comment]: # (To select your options, please put an 'x' in the all boxes that apply.)
[comment]: # (If you're unsure about any of these, don't hesitate to ask. We're here to help!.)

- [ ] I have signed the Rokwire Contributor License Agreement ([CLA](https://rokwire.org/rokwire_cla)). (_Any contributor who is not an employee of the University of Illinois whose official duties include contributing to the Rokwire software, or who is not paid by the Rokwire project, needs to sign the CLA before their contribution can be accepted._)
- [ ] I have updated the [CHANGELOG](../CHANGELOG.md).
- [ ] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My change requires updating the documentation.
- [ ] I have made necessary changes to the documentation.
- [ ] I have added tests related to my changes.
- [ ] My changes generate no new warnings.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

---

[comment]: # (Template credit: This pull request template is based on Embedded Artistry {https://github.com/embeddedartistry/templates/blob/master/.github/PULL_REQUEST_TEMPLATE.md}, Clowder {https://github.com/clowder-framework/clowder/blob/develop/.github/PULL_REQUEST_TEMPLATE.md}, and TalAter {https://github.com/TalAter/open-source-templates} templates.)

